### PR TITLE
Alias label (l) for plot

### DIFF
--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -183,6 +183,8 @@ class BasePlotting:
             Do not draw contours with less than `cut` number of points.
         S : string or int
             Resample smoothing factor.
+        l : str
+            Add a legend entry for the symbol or line being plotted.
         {J}
         {R}
         {B}
@@ -243,6 +245,7 @@ class BasePlotting:
         G="color",
         W="pen",
         i="columns",
+        l="label",
         C="cmap",
     )
     @kwargs_to_strings(R="sequence", i="sequence_comma")

--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -13,7 +13,7 @@ def test_legend():
     """
     fig = Figure()
 
-    h1 = fig.plot(
+    fig.plot(
         x=[-5],
         y=[5],
         region=[-10, 10, -5, 10],
@@ -21,16 +21,12 @@ def test_legend():
         frame="a",
         style="a15p",
         pen="1.5p,purple",
+        label='"I am a star!"',
+    )
+    fig.plot(x=[0], y=[5], style="t10p", color="cyan", label='"I am a triangle!"')
+    fig.plot(
+        x=[5], y=[5], style="d5p", color="yellow", pen=True, label='"I am a diamond!"'
     )
 
-    h2 = fig.plot(x=[0], y=[5], style="t10p", color="cyan")
-
-    h3 = fig.plot(x=[5], y=[5], style="d5p", color="yellow", pen=True)
-
-    fig.legend(
-        [[h1, h2, h3], ["I am a star!", "I am a triangle!", "I am a diamond!"]],
-        F=True,
-        D="g0/0+w2i+jCM",
-    )
-
+    fig.legend(spec="", box=True, position="g0/0+w2i+jCM")
     return fig


### PR DESCRIPTION
Symbols and line plots can now get an automatic legend entry using the 'label' alias for 'l' in plot. Also updated work-in-progress legend test to use this new alias.

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Needed for https://github.com/GenericMappingTools/pygmt/pull/333


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
